### PR TITLE
[Feat] 커스텀 그라디언트 추가

### DIFF
--- a/TuneCast_Project/src/components/WeatherAPI.jsx
+++ b/TuneCast_Project/src/components/WeatherAPI.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+
+//city: Seoul, Busan, Daegu, Incheon, Gwangju, Daejeon, Ulsan, Sejong
+
+let API_KEY = process.env.REACT_APP_WEATHER_API_KEY;
+
+function WeatherAPI() {
+  const [forecast, setForecast] = useState([]);
+  const [currentWeather, setCurrentWeather] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [city, setCity] = useState("Seoul");
+
+  let API_URL_Forecast = `http://api.openweathermap.org/data/2.5/forecast?q=${city},kr&appid=${API_KEY}&units=metric`;
+  let API_URL_CurrentWeather = `https://api.openweathermap.org/data/2.5/weather?q=${city},kr&appid=${API_KEY}&units=metric`
+
+  useEffect(() => {
+    if (isLoading) {
+      fetch(API_URL_Forecast).then(
+        function (res) {
+          return res.json().then(function (res3) {
+            console.log(res3.list);
+            setForecast(res3.list);
+            setIsLoading(false);
+          });
+        }
+      )
+    }
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (isLoading) {
+      fetch(API_URL_CurrentWeather).then(
+        function (res) {
+          return res.json().then(function (res2) {
+            console.log(res2);
+            setCurrentWeather(res2);
+          });
+        }
+      )
+    }
+  }, [isLoading]);
+
+  useEffect(() => {
+    setIsLoading(true);
+  }, [city]);
+
+  return <div>
+    <button onClick={() => setIsLoading((loading) => true)}>
+      데이터 로딩하기
+    </button>
+
+    <CityButtonComponent setCity={setCity} />
+  </div>;
+}
+
+export default WeatherAPI;
+
+function CityButtonComponent({ setCity }) {
+  const cityName = [
+    { name: "서울", nameEng: "Seoul" },
+    { name: "부산", nameEng: "Busan" },
+    { name: "대전", nameEng: "Daejeon" },
+    { name: "대구", nameEng: "Daegu" },
+    { name: "인천", nameEng: "Incheon" },
+    { name: "광주", nameEng: "Gwangju" },
+    { name: "울산", nameEng: "Ulsan" },
+    { name: "세종", nameEng: "Sejong" }
+  ]
+  const handleCityButton = (newCity) => {
+    console.log(newCity);
+    setCity(newCity);
+  };
+
+  return (
+    <div>
+      {cityName.map((city, idx) => (
+        <button key={idx} onClick={() => handleCityButton(city.nameEng)}> {city.name} </button>
+      ))}
+    </div>
+  );
+}
+
+

--- a/TuneCast_Project/src/styles/Gradient.js
+++ b/TuneCast_Project/src/styles/Gradient.js
@@ -1,13 +1,26 @@
-// 사용할 파일에서 import { gradients } from './gradients'; 로 불러와서 사용
-//
+// 사용할 파일에서 import { fetchGradient } from 'styles/gradient.js' 로 불러와서 사용
+// fetchGradient(weather) 로 사용하면 해당 날씨에 맞는 gradient를 반환
+// weather은 WeatherAPI.jsx파일의 currentWeather.weather
 
-// Thunderstorm, Drizzle, Mist, Smoke, Haze, Dust, Fog, Sand, Ash, Squall, Tornado 
+// Thunderstorm, Dust, Sand, Ash, Tornado 
+
 // Clear, Clouds, Rain, Snow, Fog
+// Rain -> Drizzle, Squall
+// Fog -> Mist, Smoke, Hase
 const gradients = {
   Clear: "linear-gradient(to bottom, #A1C4FD, #C2E9FB)",
   Cloud: "linear-gradient(to bottom, #89BCE0, #B7B7B7)",
+
   Fog: "linear-gradient(to bottom, #A8CAC8, #FF5733)",
+  Mist: "linear-gradient(to bottom, #A8CAC8, #FF5733)",
+  Smoke: "linear-gradient(to bottom, #A8CAC8, #FF5733)",
+  Haze: "linear-gradient(to bottom, #A8CAC8, #FF5733)",
+
+
   Rain: "linear-gradient(to bottom, #2B5876, #4E4376)",
+  Drizzle: "linear-gradient(to bottom, #2B5876, #4E4376)",
+  Squall: "linear-gradient(to bottom, #2B5876, #4E4376)",
+
   Snow: "linear-gradient(to bottom, #DAD4EC, #F3E7E9)"
 };
 

--- a/TuneCast_Project/src/styles/Gradient.js
+++ b/TuneCast_Project/src/styles/Gradient.js
@@ -1,0 +1,16 @@
+// 사용할 파일에서 import { gradients } from './gradients'; 로 불러와서 사용
+//
+
+// Thunderstorm, Drizzle, Mist, Smoke, Haze, Dust, Fog, Sand, Ash, Squall, Tornado 
+// Clear, Clouds, Rain, Snow, Fog
+const gradients = {
+  Clear: "linear-gradient(to bottom, #A1C4FD, #C2E9FB)",
+  Cloud: "linear-gradient(to bottom, #89BCE0, #B7B7B7)",
+  Fog: "linear-gradient(to bottom, #A8CAC8, #FF5733)",
+  Rain: "linear-gradient(to bottom, #2B5876, #4E4376)",
+  Snow: "linear-gradient(to bottom, #DAD4EC, #F3E7E9)"
+};
+
+export function fetchGradient(weather) {
+  return gradients[weather];
+}

--- a/TuneCast_Project/src/utils/WeatherAPIFunctions.js
+++ b/TuneCast_Project/src/utils/WeatherAPIFunctions.js
@@ -1,0 +1,45 @@
+const API_KEY = process.env.REACT_APP_WEATHER_API_KEY;
+
+export function fetchForecast(city) {
+  let API_URL_Forecast = `http://api.openweathermap.org/data/2.5/forecast?q=${city},kr&appid=${API_KEY}&units=metric`;
+  return fetch(API_URL_Forecast).then((res) => res.json());
+}
+
+export function fetchCurrentWeather(city) {
+  let API_URL_CurrentWeather = `https://api.openweathermap.org/data/2.5/weather?q=${city},kr&appid=${API_KEY}&units=metric`;
+  return fetch(API_URL_CurrentWeather).then((res) => res.json());
+}
+
+export function convertUnixToKST(unixTime) {
+  var date = new Date(unixTime * 1000);
+
+  var timezoneOffset = date.getTimezoneOffset() * 60000;
+  var kst = date.getTime() + timezoneOffset + 32400000;
+  date = new Date(kst);
+
+  var month = date.getMonth() + 1;
+  var day = date.getDate();
+  var dayOfWeek = ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
+  var hour = date.getHours();
+  var minute = date.getMinutes();
+
+  hour = hour < 10 ? '0' + hour : hour;
+  minute = minute < 10 ? '0' + minute : minute;
+
+  return `${month}월 ${day}일 ${dayOfWeek}요일 ${hour}:${minute}`;
+
+}
+
+export function convertCityName(city) {
+  const cityList = {
+    "Seoul": "서울특별시",
+    "Busan": "부산광역시",
+    "Daegu": "대구광역시",
+    "Incheon": "인천광역시",
+    "Gwangju": "광주광역시",
+    "Daejeon": "대전광역시",
+    "Ulsan": "울산광역시",
+    "Sejong": "세종특별자치시"
+  };
+  return cityList[city];
+}


### PR DESCRIPTION
### 관련이슈
- closes #3

### 변경사항
- styles/Gradient.js 파일 생성
- 사용 시 import { fetchGradient } from 'styles/Gradient.js' -> fetchGradient함수 불러와서 사용
- 각 날씨별 linearGradient 지정
- api에서 반환하는 날씨 종류가 더 다양하여 비슷한 case로 분류 

### To Reviewers
- Thunderstorm, Dust, Sand, Ash, Tornado 의 경우 기존에 지정한 case에 분류되지 않아 보류해뒀습니다. 좋은 아이디어가 있다면 공유해주세요