### PR TITLE
[Feat] weather api 추가

### DIFF
--- a/TuneCast_Project/src/components/WeatherAPI.jsx
+++ b/TuneCast_Project/src/components/WeatherAPI.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+
+//city: Seoul, Busan, Daegu, Incheon, Gwangju, Daejeon, Ulsan, Sejong
+
+let API_KEY = process.env.REACT_APP_WEATHER_API_KEY;
+
+function WeatherAPI() {
+  const [forecast, setForecast] = useState([]);
+  const [currentWeather, setCurrentWeather] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [city, setCity] = useState("Seoul");
+
+  let API_URL_Forecast = `http://api.openweathermap.org/data/2.5/forecast?q=${city},kr&appid=${API_KEY}&units=metric`;
+  let API_URL_CurrentWeather = `https://api.openweathermap.org/data/2.5/weather?q=${city},kr&appid=${API_KEY}&units=metric`
+
+  useEffect(() => {
+    if (isLoading) {
+      fetch(API_URL_Forecast).then(
+        function (res) {
+          return res.json().then(function (res3) {
+            console.log(res3.list);
+            setForecast(res3.list);
+            setIsLoading(false);
+          });
+        }
+      )
+    }
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (isLoading) {
+      fetch(API_URL_CurrentWeather).then(
+        function (res) {
+          return res.json().then(function (res2) {
+            console.log(res2);
+            setCurrentWeather(res2);
+          });
+        }
+      )
+    }
+  }, [isLoading]);
+
+  useEffect(() => {
+    setIsLoading(true);
+  }, [city]);
+
+  return <div>
+    <button onClick={() => setIsLoading((loading) => true)}>
+      데이터 로딩하기
+    </button>
+
+    <CityButtonComponent setCity={setCity} />
+  </div>;
+}
+
+export default WeatherAPI;
+
+function CityButtonComponent({ setCity }) {
+  const cityName = [
+    { name: "서울", nameEng: "Seoul" },
+    { name: "부산", nameEng: "Busan" },
+    { name: "대전", nameEng: "Daejeon" },
+    { name: "대구", nameEng: "Daegu" },
+    { name: "인천", nameEng: "Incheon" },
+    { name: "광주", nameEng: "Gwangju" },
+    { name: "울산", nameEng: "Ulsan" },
+    { name: "세종", nameEng: "Sejong" }
+  ]
+  const handleCityButton = (newCity) => {
+    console.log(newCity);
+    setCity(newCity);
+  };
+
+  return (
+    <div>
+      {cityName.map((city, idx) => (
+        <button key={idx} onClick={() => handleCityButton(city.nameEng)}> {city.name} </button>
+      ))}
+    </div>
+  );
+}
+
+

--- a/TuneCast_Project/src/components/WeatherAPI.jsx
+++ b/TuneCast_Project/src/components/WeatherAPI.jsx
@@ -8,6 +8,7 @@ import { fetchForecast, fetchCurrentWeather, convertUnixToKST, convertCityName }
 // 최저온도: forecast[index].temp_min
 // 날씨: forecast[index].weather
 
+// 현재 날씨의 경우 아래와 같이 불러서 사용
 // 위치(도시): currentWeather.cityName
 // 시간: currentWeather.dt -> ex) 5월 23일 화요일 12:00
 // currentWeather.current_temp
@@ -25,6 +26,7 @@ function WeatherAPI() {
   useEffect(() => {
     if (isLoading) {
       fetchForecast(city).then((data) => {
+        //TODO: 추후 현재날짜와 시간을 고려하여 필요한 데이터만 추출하도록 변경필요 (시작 데이터가 현재시간이 아님)
         const filteredData = data.list.filter((item, index) => index % 8 === 0);
         const forecastData = filteredData.map((item) => ({
           temp_max: item.main.temp_max,

--- a/TuneCast_Project/src/utils/WeatherAPIFunctions.js
+++ b/TuneCast_Project/src/utils/WeatherAPIFunctions.js
@@ -1,0 +1,45 @@
+const API_KEY = process.env.REACT_APP_WEATHER_API_KEY;
+
+export function fetchForecast(city) {
+  let API_URL_Forecast = `http://api.openweathermap.org/data/2.5/forecast?q=${city},kr&appid=${API_KEY}&units=metric`;
+  return fetch(API_URL_Forecast).then((res) => res.json());
+}
+
+export function fetchCurrentWeather(city) {
+  let API_URL_CurrentWeather = `https://api.openweathermap.org/data/2.5/weather?q=${city},kr&appid=${API_KEY}&units=metric`;
+  return fetch(API_URL_CurrentWeather).then((res) => res.json());
+}
+
+export function convertUnixToKST(unixTime) {
+  var date = new Date(unixTime * 1000);
+
+  var timezoneOffset = date.getTimezoneOffset() * 60000;
+  var kst = date.getTime() + timezoneOffset + 32400000;
+  date = new Date(kst);
+
+  var month = date.getMonth() + 1;
+  var day = date.getDate();
+  var dayOfWeek = ["일", "월", "화", "수", "목", "금", "토"][date.getDay()];
+  var hour = date.getHours();
+  var minute = date.getMinutes();
+
+  hour = hour < 10 ? '0' + hour : hour;
+  minute = minute < 10 ? '0' + minute : minute;
+
+  return `${month}월 ${day}일 ${dayOfWeek}요일 ${hour}:${minute}`;
+
+}
+
+export function convertCityName(city) {
+  const cityList = {
+    "Seoul": "서울특별시",
+    "Busan": "부산광역시",
+    "Daegu": "대구광역시",
+    "Incheon": "인천광역시",
+    "Gwangju": "광주광역시",
+    "Daejeon": "대전광역시",
+    "Ulsan": "울산광역시",
+    "Sejong": "세종특별자치시"
+  };
+  return cityList[city];
+}


### PR DESCRIPTION
### 관련이슈
- closes: #6 

### 변경사항
- 5일 예보의 경우 forecast[index].temp_max 와 같은 형태로 사용
- 현재 예보의 경우 currentWeather.current_temp 와 같은 형태로 사용
- 위와 같이 사용할 경우 화면에 바로 적용 가능한 형태로 변환되어있습니다. 

- 지역 선택 시 api 다시 fetch하는 기능 추가 -> WeatherAPI에서 정의한 CityButtonComponent 를 사용하여 위치 선택 메뉴를 구현해주세요. 디자인은 피그마에 맞춰서 수정해주시길 바랍니다.

- api fetch함수는 별도로 정의함